### PR TITLE
[DESCW-3080] Add CHEFS API authentication headers to requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bcgov/digital-engagement-solutions-custom-web
+* @mhaswell-bcgov @ShawnTurple

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # WordPress CHEFS Integration Plugin
+
+## Getting started
+1. Copy sample.env and rename it .env.
+2. Add form id of your producer form as `PRODUCER_FORM_ID`.
+   1. This can be found in the URL when viewing the form in CHEFS.
+3. Add form API key of your producer form as `PRODUCER_FORM_API_KEY`.
+   1. This must be generated in CHEFS for your form under Api key > Generate API Key.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "autoload": {
         "psr-4": {
-          "Bcgov\\WordpressChefsIntegration\\": "src/"
+          "Bcgov\\WordpressChefsIntegration\\": "src/Bcgov/WordpressChefsIntegration/"
         }
     },
     "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -17,15 +17,25 @@
  * @package WordpressChefsIntegration
  */
 
+use Bcgov\WordpressChefsIntegration\HttpClient;
 use Bcgov\WordpressChefsIntegration\RestController;
 
 $local_composer = __DIR__ . '/vendor/autoload.php';
 if ( file_exists( $local_composer ) ) {
     require_once $local_composer;
 }
-if ( ! class_exists( 'Bcgov\\NaadConnector\\RestController' ) ) {
+if ( ! class_exists( 'Bcgov\\WordpressChefsIntegration\\RestController' ) ) {
 	return;
 }
 
-$controller = new RestController();
-$controller->init();
+$env                  = parse_ini_file( '.env' );
+$producer_http_client = new HttpClient(
+    $env['CHEFS_API_URL'],
+    $env['PRODUCER_FORM_ID'],
+    $env['PRODUCER_FORM_API_KEY'],
+);
+$producer_controller  = new RestController(
+    $producer_http_client,
+    'producer'
+);
+$producer_controller->init();

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,3 @@
+CHEFS_API_URL=http://host.docker.internal:8080/app/api/v1/
+PRODUCER_FORM_ID=
+PRODUCER_FORM_API_KEY=

--- a/src/Bcgov/WordpressChefsIntegration/HttpClient.php
+++ b/src/Bcgov/WordpressChefsIntegration/HttpClient.php
@@ -1,0 +1,84 @@
+<?php
+namespace Bcgov\WordpressChefsIntegration;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * HttpClient for making requests to CHEFS API.
+ */
+class HttpClient {
+
+    /**
+     * The url to the CHEFS API.
+     *
+     * @var string
+     */
+    protected $chefs_api_url;
+
+    /**
+     * The id of the form.
+     *
+     * @var string
+     */
+    protected $form_id;
+
+    /**
+     * The API key of the form.
+     *
+     * @var string
+     */
+    protected $api_key;
+
+    /**
+     * Constructor for HttpClient.
+     *
+     * @param string $chefs_api_url
+     * @param string $form_id
+     * @param string $api_key
+     */
+    public function __construct(
+        string $chefs_api_url,
+        string $form_id,
+        string $api_key
+    ) {
+        $this->chefs_api_url = $chefs_api_url;
+        $this->form_id       = $form_id;
+        $this->api_key       = $api_key;
+    }
+
+    /**
+     * Perform a request to the specified endpoint.
+     *
+     * @param string $endpoint
+     * @param string $method
+     * @param string $body
+     * @param array  $headers
+     * @return array|WP_Error
+     */
+    public function do_request(
+        string $endpoint,
+        string $method = 'GET',
+        string $body = '',
+        array $headers = []
+    ) {
+        // Set up url and request arguments, merge in any extra headers.
+        $url  = $this->chefs_api_url . '/' . $endpoint;
+        $args = [
+            'method'  => $method,
+            'headers' => [
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json; charset=utf-8',
+                'Authorization' => 'Basic ' . base64_encode( $this->form_id . ':' . $this->api_key ),
+            ],
+        ];
+
+        $args['headers'] = array_merge( $args['headers'], $headers );
+
+        // Perform request.
+        $raw_response = wp_remote_request( $url, $args );
+
+        return $raw_response;
+    }
+}

--- a/src/Bcgov/WordpressChefsIntegration/HttpClient.php
+++ b/src/Bcgov/WordpressChefsIntegration/HttpClient.php
@@ -64,7 +64,7 @@ class HttpClient {
         array $headers = []
     ) {
         // Set up url and request arguments, merge in any extra headers.
-        $url  = $this->chefs_api_url . '/' . $endpoint;
+        $url  = $this->chefs_api_url . $endpoint;
         $args = [
             'method'  => $method,
             'headers' => [

--- a/src/Bcgov/WordpressChefsIntegration/RestController.php
+++ b/src/Bcgov/WordpressChefsIntegration/RestController.php
@@ -1,6 +1,8 @@
 <?php
 namespace Bcgov\WordpressChefsIntegration;
 
+use Bcgov\WordpressChefsIntegration\HttpClient;
+
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
@@ -9,6 +11,34 @@ use WP_Error;
  * RestController class for handling REST API endpoints.
  */
 class RestController {
+
+    /**
+     * The HttpClient to make the requests.
+     *
+     * @var HttpClient
+     */
+    protected $http_client;
+
+    /**
+     * The endpoint this controller is for, eg. "producer", "product".
+     *
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Constructor for RestController.
+     *
+     * @param HttpClient $http_client The HttpClient instance to use to make requests to CHEFS API.
+     * @param string     $endpoint    The name of the WP REST API endpoint to create.
+     */
+    public function __construct(
+        HttpClient $http_client,
+        string $endpoint
+    ) {
+        $this->http_client = $http_client;
+        $this->endpoint    = $endpoint;
+    }
 
     /**
      * Initializes the RestController Class.
@@ -27,22 +57,23 @@ class RestController {
     public function register_chefs_routes() {
         register_rest_route(
             'chefs/v1',
-            '/producer',
+            '/' . $this->endpoint,
             [
                 'methods'             => 'POST',
-                'callback'            => [ $this, 'handle_producer' ],
+                'callback'            => [ $this, 'endpoint_callback' ],
                 'permission_callback' => [ $this, 'has_permission' ],
             ]
         );
     }
 
     /**
-     * Callback function for handling requests to the producer endpoint.
+     * Callback function for handling requests to the endpoint.
      *
      * @param WP_REST_Request $request
      * @return WP_REST_Response|WP_Error
      */
-    public function handle_producer( $request ) {
+    public function endpoint_callback( $request ) {
+        // $this->http_client->do_request('submission/' . $request->submissionId);
         return rest_ensure_response( [ 'message' => 'success' ] );
     }
 

--- a/src/Bcgov/WordpressChefsIntegration/RestController.php
+++ b/src/Bcgov/WordpressChefsIntegration/RestController.php
@@ -73,7 +73,7 @@ class RestController {
      * @return WP_REST_Response|WP_Error
      */
     public function endpoint_callback( $request ) {
-        // $this->http_client->do_request('submission/' . $request->submissionId);
+        // $this->http_client->do_request('submissions/' . $request->submissionId);
         return rest_ensure_response( [ 'message' => 'success' ] );
     }
 


### PR DESCRIPTION
Create HttpClient to separate CHEFS API interaction from WP REST API code
Add do_request() and authentication headers to work with CHEFS API
Add sample.env and .env handling for providing CHEFS form ids and API keys
Update RestController to be generic rather than specific to producer endpoint
Fix bug in composer.json autoload not using correct path to source files
Update README to explain how to start using the plugin
Update CODEOWNERS to limit who is expected to review PRs