### PR TITLE
[DESCW-3081] Add request back to CHEFS API to get submission details

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,8 +1,6 @@
 <?php
 namespace Bcgov\WordpressChefsIntegration;
 
-use WP_REST_Request;
-use WP_REST_Response;
 use WP_Error;
 
 /**
@@ -49,6 +47,16 @@ class HttpClient {
     }
 
     /**
+     * Get submission details by submission id.
+     *
+     * @param string $submission_id
+     * @return array|WP_Error
+     */
+    public function get_submission( string $submission_id ) {
+        return $this->do_request( 'submission/' . $submission_id );
+    }
+
+    /**
      * Perform a request to the specified endpoint.
      *
      * @param string $endpoint
@@ -57,7 +65,7 @@ class HttpClient {
      * @param array  $headers
      * @return array|WP_Error
      */
-    public function do_request(
+    protected function do_request(
         string $endpoint,
         string $method = 'GET',
         string $body = '',

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -72,9 +72,31 @@ class RestController {
      * @param WP_REST_Request $request
      * @return WP_REST_Response|WP_Error
      */
-    public function endpoint_callback( $request ) {
-        // $this->http_client->do_request('submissions/' . $request->submissionId);
-        return rest_ensure_response( [ 'message' => 'success' ] );
+    public function endpoint_callback( WP_REST_Request $request ) {
+        $subscription_event = $request->get_param( 'subscriptionEvent' );
+        if ( 'eventSubmission' !== $subscription_event ) {
+            return rest_ensure_response( [ 'message' => 'Not eventSubmission event. Ignoring.' ] );
+        }
+
+        $submission_id = $request->get_param( 'submissionId' );
+        if ( ! $submission_id ) {
+            $response = new WP_REST_Response(
+                [ 'message' => 'Must provide a submissionId parameter.' ],
+                400
+            );
+            return rest_ensure_response( $response );
+        }
+
+        $submission = $this->http_client->get_submission( $submission_id );
+        if ( is_wp_error( $submission ) ) {
+            $response = new WP_REST_Response(
+                [ 'message' => 'Error getting submission: ' . $submission->get_error_message() ],
+                400
+            );
+            return rest_ensure_response( $response );
+        }
+
+        return rest_ensure_response( [ 'message' => 'Success.' ] );
     }
 
     /**

--- a/tests/test-RestController.php
+++ b/tests/test-RestController.php
@@ -67,4 +67,120 @@ class RestControllerTest extends WP_UnitTestCase {
         $this->assertEquals( [ $this->controller, 'endpoint_callback' ], $route['callback'] );
         $this->assertEquals( [ $this->controller, 'has_permission' ], $route['permission_callback'] );
     }
+
+    /**
+     * Tests the POST endpoint callback.
+     *
+     * @dataProvider provider_test_post
+     * @param object         $request The request from CHEFS' event subscription service.
+     * @param array|WP_Error $chefs_response The response to our request to CHEFS API.
+     * @param object         $expects The assertions we are making about the tests.
+     * @return void
+     */
+    public function test_post( object $request, $chefs_response, object $expects ) {
+        $this->http_client
+            ->expects( $this->exactly( $expects->times ) )
+            ->method( 'get_submission' )
+            ->with( $request->body->submissionId ?? null )
+            ->willReturn( $chefs_response );
+
+        $response = $this->send_request( $request );
+
+        $this->assertSame( $expects->status, $response->get_status() );
+    }
+
+    /**
+     * Data provider for test_post().
+     *
+     * @return array
+     */
+    public function provider_test_post() {
+        return [
+            'Success'                 => [
+                'request'        => (object) [
+                    'method' => 'POST',
+                    'body'   => (object) [
+                        'formId'            => 'c78ef40a-ad9c-4f81-8c38-bf4ff0187f38',
+                        'formVersion'       => 'a3dbd953-bffd-44ea-ab1c-5e09c9dcbb5f',
+                        'subscriptionEvent' => 'eventSubmission',
+                        'submissionId'      => 'a94984b1-7c7c-4cbd-8a55-10fda3cd9319',
+                    ],
+                ],
+                'chefs_response' => [
+                    'test' => 'test',
+                ],
+                'expects'        => (object) [
+                    'times'  => 1,
+                    'status' => 200,
+                ],
+            ],
+            'Wrong subscriptionEvent' => [
+                'request'        => (object) [
+                    'method' => 'POST',
+                    'body'   => (object) [
+                        'formId'            => 'c78ef40a-ad9c-4f81-8c38-bf4ff0187f38',
+                        'formVersion'       => 'a3dbd953-bffd-44ea-ab1c-5e09c9dcbb5f',
+                        'subscriptionEvent' => 'notEventSubmission',
+                        'submissionId'      => 'a94984b1-7c7c-4cbd-8a55-10fda3cd9319',
+                    ],
+                ],
+                'chefs_response' => [
+                    'test' => 'test',
+                ],
+                'expects'        => (object) [
+                    'times'  => 0,
+                    'status' => 200,
+                ],
+            ],
+            'Missing submissionId'    => [
+                'request'        => (object) [
+                    'method' => 'POST',
+                    'body'   => (object) [
+                        'formId'            => 'c78ef40a-ad9c-4f81-8c38-bf4ff0187f38',
+                        'formVersion'       => 'a3dbd953-bffd-44ea-ab1c-5e09c9dcbb5f',
+                        'subscriptionEvent' => 'eventSubmission',
+                    ],
+                ],
+                'chefs_response' => [
+                    'test' => 'test',
+                ],
+                'expects'        => (object) [
+                    'times'  => 0,
+                    'status' => 400,
+                ],
+            ],
+            'Error from CHEFS API'    => [
+                'request'        => (object) [
+                    'method' => 'POST',
+                    'body'   => (object) [
+                        'formId'            => 'c78ef40a-ad9c-4f81-8c38-bf4ff0187f38',
+                        'formVersion'       => 'a3dbd953-bffd-44ea-ab1c-5e09c9dcbb5f',
+                        'subscriptionEvent' => 'eventSubmission',
+                        'submissionId'      => 'a94984b1-7c7c-4cbd-8a55-10fda3cd9319',
+                    ],
+                ],
+                'chefs_response' => new WP_Error( 'error' ),
+                'expects'        => (object) [
+                    'times'  => 1,
+                    'status' => 400,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Helper function for sending a request to our API endpoint.
+     *
+     * @param object $request_file
+     * @return WP_REST_Response|WP_Error
+     */
+    private function send_request( object $request_file ) {
+        $request = new WP_REST_Request( $request_file->method, '/chefs/v1/' . $this->endpoint );
+        $request->set_body( wp_json_encode( $request_file->body ) );
+        $request->add_header( 'Content-Type', 'application/json' );
+
+        // TODO: Make actual request instead of faking it through the callback.
+        // return rest_get_server()->dispatch($request);.
+        return $this->controller->endpoint_callback( $request );
+    }
 }


### PR DESCRIPTION
Improve error handling in endpoint callback
Add get_submission() to HttpClient to get submission details by id
Improve unit test cases